### PR TITLE
Cxitool does not compile for me, this fixes it.

### DIFF
--- a/src/CxiBuilder.cpp
+++ b/src/CxiBuilder.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include "CxiBuilder.h"
 #include "3dsx_loader.h"
 


### PR DESCRIPTION
Cxitool would not compile for me (offsetof(...) was undefined in CxiBuilder.cpp); to fix it all I had to do was include stddef.h.
