### PR TITLE
Added standalone mkromfs3ds tool for independent romfs packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile
 3dsxdump
 3dsxtool
 smdhtool
+mkromfs3ds
 .deps/
 *.bz2
 .dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 # Makefile.am -- Process this file with automake to produce Makefile.in
-bin_PROGRAMS = 3dsxtool 3dsxdump smdhtool
+bin_PROGRAMS = 3dsxtool 3dsxdump smdhtool mkromfs3ds
 
 _common_SOURCES	=	src/types.h src/FileClass.h
 _lodepng_SOURCES	=	src/lodepng/lodepng.cpp src/lodepng/lodepng.h
@@ -9,5 +9,7 @@ _lodepng_SOURCES	=	src/lodepng/lodepng.cpp src/lodepng/lodepng.h
 3dsxdump_CXXFLAGS	=
 smdhtool_SOURCES	=	src/smdhtool.cpp $(_lodepng_SOURCES) $(_common_SOURCES)
 smdhtool_CXXFLAGS	=
+mkromfs3ds_SOURCES	=	src/mkromfs3ds.cpp src/romfs.cpp src/romfs.h $(_common_SOURCES)
+mkromfs3ds_CXXFLAGS	=
 
 EXTRA_DIST = autogen.sh

--- a/src/mkromfs3ds.cpp
+++ b/src/mkromfs3ds.cpp
@@ -16,20 +16,6 @@ using std::map;
 #define die(msg) do { fputs(msg "\n\n", stderr); return 1; } while(0)
 #define safe_call(a) do { int rc = a; if(rc != 0) return rc; } while(0)
 
-#ifdef WIN32
-static inline char* FixMinGWPath(char* buf)
-{
-	if (*buf == '/')
-	{
-		buf[0] = buf[1];
-		buf[1] = ':';
-	}
-	return buf;
-}
-#else
-#define FixMinGWPath(_arg) (_arg)
-#endif
-
 struct argInfo
 {
 	char* outFile;
@@ -55,8 +41,8 @@ int parseArgs(argInfo& info, int argc, char* argv[])
 		char* arg = argv[i];
 		switch (status++)
 		{
-			case 1: info.outFile = FixMinGWPath(arg); break;
-			case 0: info.romfsDir = FixMinGWPath(arg); break;
+			case 1: info.outFile = arg; break;
+			case 0: info.romfsDir = arg; break;
 			default: return usage(argv[0]);
 		}
 	}

--- a/src/mkromfs3ds.cpp
+++ b/src/mkromfs3ds.cpp
@@ -1,0 +1,77 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+#include <map>
+#include <list>
+#include <algorithm>
+#include "types.h"
+#include "elf.h"
+#include "FileClass.h"
+#include "romfs.h"
+
+using std::vector;
+using std::map;
+
+#define die(msg) do { fputs(msg "\n\n", stderr); return 1; } while(0)
+#define safe_call(a) do { int rc = a; if(rc != 0) return rc; } while(0)
+
+#ifdef WIN32
+static inline char* FixMinGWPath(char* buf)
+{
+	if (*buf == '/')
+	{
+		buf[0] = buf[1];
+		buf[1] = ':';
+	}
+	return buf;
+}
+#else
+#define FixMinGWPath(_arg) (_arg)
+#endif
+
+struct argInfo
+{
+	char* outFile;
+	char* romfsDir;
+};
+
+int usage(const char* progName)
+{
+	fprintf(stderr,
+		"Usage:\n"
+		"    %s input_dir output.romfs\n\n"
+		, progName);
+	return 1;
+}
+
+int parseArgs(argInfo& info, int argc, char* argv[])
+{
+	memset(&info, 0, sizeof(info));
+
+	int status = 0;
+	for (int i = 1; i < argc; i ++)
+	{
+		char* arg = argv[i];
+		switch (status++)
+		{
+			case 1: info.outFile = FixMinGWPath(arg); break;
+			case 0: info.romfsDir = FixMinGWPath(arg); break;
+			default: return usage(argv[0]);
+		}
+	}
+	return status < 2 ? usage(argv[0]) : 0;
+}
+
+int main(int argc, char* argv[])
+{
+	argInfo args;
+	safe_call(parseArgs(args, argc, argv));
+
+	RomFS romfs;
+	safe_call(romfs.Build(args.romfsDir));
+	FileClass fout(args.outFile, "wb");
+	safe_call(romfs.WriteToFile(fout));
+
+	return 0;
+}


### PR DESCRIPTION
Because SD card access is so slow, user-supplied assets are best packaged in romfs files (as I do in https://github.com/ds-sloth/TheXTech3DS/blob/master/libs/AppPath/app_path.cpp#L95) but there is currently no frontend tool for users to package romfs files without unnecessarily building a rom.
I provide a simple frontend tool `mkromfs3ds` that accomplishes this task.
Please let me know if you would be willing to upstream it in the primary devkitpro code.
Thank you for your consideration.